### PR TITLE
do not use unique names by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Deployment: 8 mins
 | firestore\_location | Firestore location, see https://firebase.google.com/docs/firestore/locations | `string` | `"nam5"` | no |
 | project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
 | region | The Google Cloud region to deploy to | `string` | `"us-central1"` | no |
+| unique\_names | Whether to use unique names for resources | `bool` | `false` | no |
 | webhook\_path | Path to the webhook source directory | `string` | `"webhook"` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -38,10 +38,21 @@ resource "random_id" "unique_id" {
   byte_length = 3
 }
 
+locals {
+  bucket_main_name   = var.unique_names ? "${var.project_id}-main-${random_id.unique_id.hex}" : "${var.project_id}-main"
+  bucket_docs_name   = var.unique_names ? "${var.project_id}-docs-${random_id.unique_id.hex}" : "${var.project_id}-docs"
+  webhook_name       = var.unique_names ? "webhook-${random_id.unique_id.hex}" : "webhook"
+  webhook_sa_name    = var.unique_names ? "webhook-service-account-${random_id.unique_id.hex}" : "webhook-service-account"
+  trigger_name       = var.unique_names ? "trigger-${random_id.unique_id.hex}" : "trigger"
+  trigger_sa_name    = var.unique_names ? "trigger-service-account-${random_id.unique_id.hex}" : "trigger-service-account"
+  ocr_processor_name = var.unique_names ? "ocr-processor-${random_id.unique_id.hex}" : "ocr-processor"
+  firestore_name     = var.unique_names ? "tuning-dataset-${random_id.unique_id.hex}" : "tuning-dataset"
+}
+
 #-- Cloud Storage buckets --#
 resource "google_storage_bucket" "main" {
   project                     = module.project_services.project_id
-  name                        = "${var.project_id}-${random_id.unique_id.hex}"
+  name                        = local.bucket_main_name
   location                    = var.region
   force_destroy               = true
   uniform_bucket_level_access = true
@@ -49,7 +60,7 @@ resource "google_storage_bucket" "main" {
 
 resource "google_storage_bucket" "docs" {
   project                     = module.project_services.project_id
-  name                        = "${var.project_id}-docs-${random_id.unique_id.hex}"
+  name                        = local.bucket_docs_name
   location                    = var.region
   force_destroy               = true
   uniform_bucket_level_access = true
@@ -58,7 +69,7 @@ resource "google_storage_bucket" "docs" {
 #-- Cloud Function webhook --#
 resource "google_cloudfunctions2_function" "webhook" {
   project  = module.project_services.project_id
-  name     = "webhook-${random_id.unique_id.hex}"
+  name     = local.webhook_name
   location = var.region
 
   build_config {
@@ -98,7 +109,7 @@ resource "google_project_iam_member" "webhook" {
 }
 resource "google_service_account" "webhook" {
   project      = module.project_services.project_id
-  account_id   = "webhook-service-account-${random_id.unique_id.hex}"
+  account_id   = local.webhook_sa_name
   display_name = "Cloud Functions webhook service account"
 }
 
@@ -118,7 +129,7 @@ resource "google_storage_bucket_object" "webhook_staging" {
 resource "google_eventarc_trigger" "trigger" {
   project         = module.project_services.project_id
   location        = var.region
-  name            = "trigger-${random_id.unique_id.hex}"
+  name            = local.trigger_name
   service_account = google_service_account.trigger.email
 
   matching_criteria {
@@ -149,7 +160,7 @@ resource "google_project_iam_member" "trigger" {
 }
 resource "google_service_account" "trigger" {
   project      = module.project_services.project_id
-  account_id   = "trigger-service-account-${random_id.unique_id.hex}"
+  account_id   = local.trigger_sa_name
   display_name = "Eventarc trigger service account"
 }
 
@@ -178,14 +189,14 @@ resource "google_project_service_identity" "eventarc_agent" {
 resource "google_document_ai_processor" "ocr" {
   project      = module.project_services.project_id
   location     = var.documentai_location
-  display_name = "ocr-processor-${random_id.unique_id.hex}"
+  display_name = local.ocr_processor_name
   type         = "OCR_PROCESSOR"
 }
 
 #-- Firestore --#
 resource "google_firestore_database" "main" {
   project         = module.project_services.project_id
-  name            = "questions-${random_id.unique_id.hex}"
+  name            = local.firestore_name
   location_id     = var.firestore_location
   type            = "FIRESTORE_NATIVE"
   deletion_policy = "DELETE"

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -43,6 +43,10 @@ spec:
         region:
           name: region
           title: Region
+        unique_names:
+          name: unique_names
+          title: Unique Names
+          invisible: true
         webhook_path:
           name: webhook_path
           title: Webhook Path

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -93,6 +93,10 @@ spec:
         description: The Google Cloud region to deploy to
         varType: string
         defaultValue: us-central1
+      - name: unique_names
+        description: Whether to use unique names for resources
+        varType: bool
+        defaultValue: false
       - name: webhook_path
         description: Path to the webhook source directory
         varType: string

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 output "neos_walkthrough_url" {
-  value       = "https://console.cloud.google.com/products/solutions/deployments?walkthrough_id=panels--sic--document-summarization-gcf_tour"
+  value       = "https://console.cloud.google.com/products/solutions/deployments?walkthrough_id=panels--sic--document-knowledge-base-tour"
   description = "The URL to launch the in-console tutorial for the Generative AI Knowledge Base solution"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -56,3 +56,8 @@ variable "webhook_path" {
   default     = "webhook"
 }
 
+variable "unique_names" {
+  description = "Whether to use unique names for resources"
+  type        = bool
+  default     = false
+}

--- a/webhook/test_e2e.py
+++ b/webhook/test_e2e.py
@@ -48,6 +48,7 @@ def outputs() -> Iterator[dict[str, str]]:
             "-input=false",
             "-auto-approve",
             f"-var=project_id={PROJECT_ID}",
+            "-var=unique_names=true",
             "-target=google_storage_bucket.main",
             "-target=google_document_ai_processor.ocr",
             "-target=google_firestore_database.main",


### PR DESCRIPTION
Only use unique names for testing to avoid name clashes. Otherwise during a "normal deployment" names won't be unique. This makes names look nicer and are more predictable for the Neos tutorial.