### PR TITLE
feat: improve image building performance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,8 +125,15 @@ resource "google_artifact_registry_repository" "webhook_images" {
 }
 
 data "archive_file" "webhook_staging" {
-  type        = "zip"
-  source_dir  = var.webhook_path
+  type       = "zip"
+  source_dir = var.webhook_path
+  excludes = [
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "env",
+  ]
   output_path = abspath("./.tmp/webhook.zip")
 }
 

--- a/webhook/.gcloudignore
+++ b/webhook/.gcloudignore
@@ -1,5 +1,0 @@
-.mypy_cache/
-.pytest_cache/
-.ruff_cache/
-__pycache__/
-env/

--- a/webhook/.gcloudignore
+++ b/webhook/.gcloudignore
@@ -1,0 +1,5 @@
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+env/


### PR DESCRIPTION
By excluding unnecessary directories that could be present, especially during local runs, this brings down the source size and image size to what's barely necessary.