### PR TITLE
bug: use unique name since webhook-service-account is also used in ge…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -59,5 +59,5 @@ variable "webhook_path" {
 variable "unique_names" {
   description = "Whether to use unique names for resources"
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
…nai-doc-summarization solution

The webhook-service-account is used in another solution (terraform-genai-document-summarization), hence if genai-document-summarization solution is already deployed in a project, deployment of genai-knowledge-base will fail since it won't be able to create another service account with the same name. Hence recommending to use unique_names to avoid conflicts.