### PR TITLE
fix: set unique_names to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Deployment: 6 mins
 | firestore\_location | Firestore location, see https://firebase.google.com/docs/firestore/locations | `string` | `"nam5"` | no |
 | project\_id | The Google Cloud project ID to deploy to | `string` | n/a | yes |
 | region | The Google Cloud region to deploy to | `string` | `"us-central1"` | no |
-| unique\_names | Whether to use unique names for resources | `bool` | `false` | no |
+| unique\_names | Whether to use unique names for resources | `bool` | `true` | no |
 | webhook\_path | Path to the webhook source directory | `string` | `"webhook"` | no |
 
 ## Outputs

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -92,7 +92,7 @@ spec:
       - name: unique_names
         description: Whether to use unique names for resources
         varType: bool
-        defaultValue: false
+        defaultValue: true
       - name: webhook_path
         description: Path to the webhook source directory
         varType: string

--- a/variables.tf
+++ b/variables.tf
@@ -59,5 +59,5 @@ variable "webhook_path" {
 variable "unique_names" {
   description = "Whether to use unique names for resources"
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
The webhook-service-account is used in another solution (terraform-genai-document-summarization), hence if genai-document-summarization solution is already deployed in a project, deployment of genai-knowledge-base will fail since it won't be able to create another service account with the same name. Hence recommending to use unique_names to avoid conflicts.