### PR TITLE
fix: Pin bigframes to < 1.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,7 +209,7 @@ resource "google_project_service_identity" "eventarc_agent" {
   service  = "eventarc.googleapis.com"
 }
 
-#-- Document AI (OCR) --#
+#-- Document AI --#
 resource "google_document_ai_processor" "ocr" {
   project      = module.project_services.project_id
   location     = var.documentai_location

--- a/main.tf
+++ b/main.tf
@@ -209,7 +209,7 @@ resource "google_project_service_identity" "eventarc_agent" {
   service  = "eventarc.googleapis.com"
 }
 
-#-- Document AI --#
+#-- Document AI (OCR) --#
 resource "google_document_ai_processor" "ocr" {
   project      = module.project_services.project_id
   location     = var.documentai_location

--- a/webhook/requirements.txt
+++ b/webhook/requirements.txt
@@ -19,3 +19,4 @@ google-cloud-documentai==2.24.2
 google-cloud-firestore==2.15.0
 google-cloud-storage==2.14.0
 retry2==0.9.5
+bigframes<1.0.0


### PR DESCRIPTION
### Background
* Deployment of this JSS inside Cloud Console randomly started producing errors related to the Cloud Run web hook.
* See [Google-internal Chat thread here](https://chat.google.com/room/AAAAsSEbLDs/ZTWqcirmUak).
* The error was not a result of changes to this repo.
* I initially created this pull-request to reproduce the error via integeration tests. I reproduced it; albeit only through the `
terraform-genai-knowledge-base-int-trigger` check — not through the `webhook / test (3.12)` check. (Both of these GitHub checks test `terraform apply`. I'm guessing `webhook / test (3.12)` didn't fail because it's using a cached version of the image.)

### Solution
* In the aforementioned Chat thread, @glasnt suggested pinning `bigframes` to < v1 - based on [this StackOverflow post](https://stackoverflow.com/questions/78227940/import-vertex-ai-sdk-raises-attributeerror-module-bigframes-has-no-attribute).
* It seemed to have worked. See GitHub checks of commits.

### Error logs
* The Terraform errors:
```
google_cloudfunctions2_function.webhook: Creation errored after 1m41s
Error waiting for Creating function: Error code 3, message: 
Could not create or update Cloud Run service webhook-7b5fb8, Container Healthcheck failed. 
Revision 'webhook-7b5fb8-00001-mil' is not ready and cannot serve traffic. The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable. 
Logs for this revision might contain more information.
```
* The errors from the Cloud Run Revision itself:
```
File "/workspace/main.py", line 25, in <module>
    import vertexai  # type: ignore
    ^^^^^^^^^^^^^^^
File "/layers/google.python.pip/pip/lib/python3.12/site-packages/vertexai/__init__.py", line 17, in <module>
    from google.cloud.aiplatform import version as aiplatform_version
```