### PR TITLE
fix: Pin bigframes to <1.0.0 in notebook

### DIFF
--- a/notebooks/model-predictions.ipynb
+++ b/notebooks/model-predictions.ipynb
@@ -37,7 +37,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install google-cloud-aiplatform google-cloud-firestore"
+        "!pip install google-cloud-aiplatform google-cloud-firestore \"bigframes<1.0.0\""
       ],
       "metadata": {
         "id": "W9C3mHjIiZn1"


### PR DESCRIPTION
* This is similar to https://github.com/GoogleCloudPlatform/terraform-genai-knowledge-base/pull/91 and this [StackOverflow post](https://stackoverflow.com/questions/78227940/import-vertex-ai-sdk-raises-attributeerror-module-bigframes-has-no-attribute).
* We started experiencing the following issue inside this Notebook:

<img width="500" alt="Screenshot 2024-03-28 at 12 23 19 AM" src="https://github.com/GoogleCloudPlatform/terraform-genai-knowledge-base/assets/10292865/70c853ef-43c9-406b-843a-2d523af7990e">


* For now, the solution is to pin bigframes to <1.0.0 — as suggested by https://github.com/googleapis/python-aiplatform/commit/cdb8e6afc3791ca5b3c86e516dde2c3f111401f0#commitcomment-140260997.