### PR TITLE
ci: Add inline guidance on pull_request_target usage

### DIFF
--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 on:
+  # Do not use pull_request_target with actions/cache or actions/checkout.
   pull_request_target:
     types: [ opened, edited ]
 name: conventional release labels


### PR DESCRIPTION
Add guidance on safe usage of `pull_request_target`. Initial PR is providing minimal information.


