### PR TITLE
fix: Add depends_on to Eventarc trigger

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ resource "google_eventarc_trigger" "trigger" {
   }
   
   depends_on = [
-    google_project_iam_member.eventarc_agent,
+    google_project_iam_member.gcs_account,
   ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,10 @@ resource "google_eventarc_trigger" "trigger" {
       region  = var.region
     }
   }
+  
+  depends_on = [
+    google_project_iam_member.eventarc_agent,
+  ]
 }
 
 resource "google_project_iam_member" "trigger" {

--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "google_eventarc_trigger" "trigger" {
       region  = var.region
     }
   }
-  
+
   depends_on = [
     google_project_iam_member.gcs_account,
   ]


### PR DESCRIPTION
* Please see Google-internal bug: [b/372430497#comment27](http://b/372430497#comment27)
* In that bug, we encountered the following error during `terraform destroy`:
```
Error: Error deleting Trigger: operation received error: error code "7", message: 
An internal error occurred.
...
To use GCS CloudEvent triggers, the GCS service account requires the Pub/Sub Publisher (roles/pubsub.publisher) IAM role in the specified project. 1 
```

* I believe it's because the role (`roles/pubsub.publisher`) on the GCS (Google Cloud Storage) service account 
* The fix is to ensures the Eventarc trigger is deleted _before_ the GCS service account's role (`roles/pubsub.publisher`).